### PR TITLE
bump underscore deep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "underscore": "~1.5.2",
-    "underscore.deep": "~0.3.0"
+    "underscore.deep": "^0.5.1"
   },
   "devDependencies": {
     "mocha": "~1.14.0",


### PR DESCRIPTION
There have been some minor bug fixes in `underscore.deep` and this pulls them in. 